### PR TITLE
docs: fix references to internal documentation

### DIFF
--- a/docs-partials/post-processor/ucloud-import/Config-not-required.mdx
+++ b/docs-partials/post-processor/ucloud-import/Config-not-required.mdx
@@ -2,7 +2,7 @@
 
 - `ufile_key_name` (string) - The name of the object key in
    `ufile_bucket_name` where the RAW, VHD, VMDK, or qcow2 file will be copied
-   to import. This is a [template engine](/docs/templates/legacy_json_templates/engine).
+   to import. This is a [template engine](/packer/docs/templates/legacy_json_templates/engine).
    Therefore, you may use user variables and template functions in this field.
 
 - `skip_clean` (bool) - Whether we should skip removing the RAW, VHD, VMDK, or qcow2 file uploaded to

--- a/docs/builders/uhost.mdx
+++ b/docs/builders/uhost.mdx
@@ -23,7 +23,7 @@ The following configuration options are available for building UCloud images. Th
 segmented below into two categories: required and optional parameters.
 
 In addition to the options listed here, a
-[communicator](/docs/templates/legacy_json_templates/communicator) can be configured for this
+[communicator](/packer/docs/templates/legacy_json_templates/communicator) can be configured for this
 builder.
 
 ~> **Note:** The builder doesn't support Windows images for now and only supports CentOS and Ubuntu images via SSH authentication with `ssh_username` (Required) and `ssh_password` (Optional). The `ssh_username` must be `root` for CentOS images and `ubuntu` for Ubuntu images. The `ssh_password` may contain 8-30 characters, and must consist of at least 2 items out of the capital letters, lower case letters, numbers and special characters. The special characters include `()~!@#\$%^&\*-+=\_|{}\[]:;'<>,.?/`.

--- a/post-processor/ucloud-import/post-processor.go
+++ b/post-processor/ucloud-import/post-processor.go
@@ -49,7 +49,7 @@ type Config struct {
 	UFileBucket string `mapstructure:"ufile_bucket_name" required:"true"`
 	// The name of the object key in
 	//  `ufile_bucket_name` where the RAW, VHD, VMDK, or qcow2 file will be copied
-	//  to import. This is a [template engine](/docs/templates/legacy_json_templates/engine).
+	//  to import. This is a [template engine](/packer/docs/templates/legacy_json_templates/engine).
 	//  Therefore, you may use user variables and template functions in this field.
 	UFileKey string `mapstructure:"ufile_key_name" required:"false"`
 	// Whether we should skip removing the RAW, VHD, VMDK, or qcow2 file uploaded to


### PR DESCRIPTION
With the move to developer.hashicorp.com some links between the general doc and plugins were broken. This PR fixes them