### PR TITLE
[HPR-1011] Prepare plugin for repo transfer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,17 +29,18 @@ jobs:
       - name: Describe plugin
         id: plugin_describe
         run: echo "::set-output name=api_version::$(go run . describe | jq -r '.api_version')"
-      - name: Install signore
-        uses: hashicorp/setup-signore-package@v1
-
+      - name: Import GPG key
+        id: import_gpg
+        uses: crazy-max/ghaction-import-gpg@v5
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:
           version: latest
           args: release --rm-dist
         env:
+          GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           API_VERSION: ${{ steps.plugin_describe.outputs.api_version }}
-          SIGNORE_CLIENT_ID: ${{ secrets.SIGNORE_CLIENT_ID }}
-          SIGNORE_CLIENT_SECRET: ${{ secrets.SIGNORE_CLIENT_SECRET }}
-          SIGNORE_SIGNER: ${{ secrets.SIGNORE_SIGNER }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -91,10 +91,17 @@ checksum:
   name_template: '{{ .ProjectName }}_v{{ .Version }}_SHA256SUMS'
   algorithm: sha256
 signs:
-  - cmd: signore
-    args: ["sign", "--dearmor", "--file", "${artifact}", "--out", "${signature}"]
-    artifacts: checksum
-    signature: ${artifact}.sig
+ - artifacts: checksum 
+   args: 
+     # if you are using this is in a GitHub action or some other automated pipeline, you
+     # # need to pass the batch flag to indicate its not interactive.
+     - "--batch"
+     - "--local-user"
+     - "{{ .Env.GPG_FINGERPRINT  }}"
+     - "--output"
+     - "${signature}"
+     - "--detach-sign"
+     - "${artifact}"
 release:
   # If you want to manually examine the release before its live, uncomment this line:
   # draft: true

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @hashicorp/packer @shawnmssu 
+* @schnell18 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -4,7 +4,6 @@ BINARY=packer-plugin-${NAME}
 COUNT?=1
 TEST?=$(shell go list ./...)
 HASHICORP_PACKER_PLUGIN_SDK_VERSION?=$(shell go list -m github.com/hashicorp/packer-plugin-sdk | cut -d " " -f2)
-
 .PHONY: dev
 
 build:
@@ -32,5 +31,4 @@ testacc: dev
 
 generate: install-packer-sdc
 	@go generate ./...
-	packer-sdc renderdocs -src ./docs -dst ./.docs -partials ./docs-partials
 	# checkout the .docs folder for a preview of the docs


### PR DESCRIPTION
The changes in this PR are in preparation for transferring this repo from 
the HashiCorp org to the Ucloud org, where this plugin will be maintained.

- [x] Update codeonwers
- [x] Remove HashiCorp specific GPG signing from release
- [x] Remove GitHub secrets specific to HashiCorp repo.

